### PR TITLE
Add Windows script for database setup

### DIFF
--- a/database/setup_database.ps1
+++ b/database/setup_database.ps1
@@ -1,0 +1,24 @@
+# Run all DDL, DML, and CSV imports for the project database
+param(
+    [string]$PsqlPath = "psql"
+)
+
+$env:PGPASSWORD = "imart"
+$connection = "-h localhost -p 5432 -U imart -d iap_db"
+
+# Execute DDL scripts
+Get-ChildItem -Path "$(Join-Path $PSScriptRoot 'ddl')" -Filter *.txt | Sort-Object Name | ForEach-Object {
+    & $PsqlPath $connection -f $_.FullName
+}
+
+# Execute DML scripts
+Get-ChildItem -Path "$(Join-Path $PSScriptRoot 'dml')" -Filter *.sql | Sort-Object Name | ForEach-Object {
+    & $PsqlPath $connection -f $_.FullName
+}
+
+# Import CSV files
+Get-ChildItem -Path "$(Join-Path $PSScriptRoot 'csv')" -Filter *.csv | Sort-Object Name | ForEach-Object {
+    $tableName = $_.BaseName
+    $filePath = $_.FullName.Replace('\','/')
+    & $PsqlPath $connection -c "\COPY $tableName FROM '$filePath' WITH (FORMAT csv, HEADER true)"
+}


### PR DESCRIPTION
## Summary
- add PowerShell script to run ddl, dml, and csv imports for PostgreSQL

## Testing
- `powershell -Version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68bb5fafc844832ca4933987165b2722