### PR TITLE
refactor: use argument array for psql connection

### DIFF
--- a/database/setup_database.ps1
+++ b/database/setup_database.ps1
@@ -4,21 +4,21 @@ param(
 )
 
 $env:PGPASSWORD = "imart"
-$connection = "-h localhost -p 5432 -U imart -d iap_db"
+$connectionArgs = @('-h','localhost','-p','5432','-U','imart','-d','iap_db')
 
 # Execute DDL scripts
 Get-ChildItem -Path "$(Join-Path $PSScriptRoot 'ddl')" -Filter *.txt | Sort-Object Name | ForEach-Object {
-    & $PsqlPath $connection -f $_.FullName
+    & $PsqlPath @connectionArgs -f $_.FullName
 }
 
 # Execute DML scripts
 Get-ChildItem -Path "$(Join-Path $PSScriptRoot 'dml')" -Filter *.sql | Sort-Object Name | ForEach-Object {
-    & $PsqlPath $connection -f $_.FullName
+    & $PsqlPath @connectionArgs -f $_.FullName
 }
 
 # Import CSV files
 Get-ChildItem -Path "$(Join-Path $PSScriptRoot 'csv')" -Filter *.csv | Sort-Object Name | ForEach-Object {
     $tableName = $_.BaseName
     $filePath = $_.FullName.Replace('\','/')
-    & $PsqlPath $connection -c "\COPY $tableName FROM '$filePath' WITH (FORMAT csv, HEADER true)"
+    & $PsqlPath @connectionArgs -c "\COPY $tableName FROM '$filePath' WITH (FORMAT csv, HEADER true)"
 }


### PR DESCRIPTION
## Summary
- refactor PowerShell database setup script to use argument arrays for psql connection

## Testing
- `pwsh -NoLogo -NoProfile -Command "& './database/setup_database.ps1'"` *(fails: command not found)*
- `psql -h localhost -p 5432 -U imart -d iap_db -c '\\conninfo'` *(fails: connection refused)*

------
https://chatgpt.com/codex/tasks/task_e_68bbb5614468832c8a5a3d96c64a98af