### PR TITLE
Add sample user maintenance screen

### DIFF
--- a/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
+++ b/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
@@ -1,0 +1,61 @@
+<imart type="head">
+    <html lang="ja">
+    <meta charset="UTF-8">
+    <title>ユーザーメンテナンスサンプル</title>
+    <link rel="stylesheet" type="text/css" href="lo_csjs/bootstrap.css">
+    <script type="text/javascript" src="lo_csjs/jquery_wrapper.js"></script>
+    <script type="text/javascript" src="lo_csjs/bootstrap.min.js"></script>
+    <IMART type="jsspRpc" name="jsspRpcListUsers" page="lo/contents/screen/account/user_maintenance" callback="renderList"></IMART>
+    <IMART type="jsspRpc" name="jsspRpcEditUser" page="lo/contents/screen/account/user_maintenance" callback="editResult"></IMART>
+</imart>
+<body class="container mt-3">
+    <h1>ユーザーメンテナンスサンプル</h1>
+    <div class="mb-3">
+        <input type="text" id="query" class="form-control" placeholder="ユーザーID検索">
+        <button id="searchBtn" class="btn btn-primary mt-2">検索</button>
+    </div>
+    <table class="table" id="userTable">
+        <thead>
+            <tr><th>ユーザーID</th><th>表示名</th><th>削除</th></tr>
+        </thead>
+        <tbody></tbody>
+    </table>
+    <h2 class="mt-4">編集</h2>
+    <div class="mb-3">
+        <input type="text" id="editUserCd" class="form-control mb-1" placeholder="userCd">
+        <input type="text" id="editUserName" class="form-control mb-1" placeholder="userName">
+        <input type="text" id="editEmail" class="form-control mb-1" placeholder="emailAddress1">
+        <button id="saveBtn" class="btn btn-success">保存</button>
+    </div>
+    <script type="text/javascript">
+    function renderList(res) {
+        var tbody = $("#userTable tbody");
+        tbody.empty();
+        if (res && res.rows) {
+            res.rows.forEach(function(r){
+                var tr = $("<tr>");
+                tr.append($("<td>").text(r.userCd));
+                tr.append($("<td>").text(r.displayName));
+                tr.append($("<td>").text(r.deleted ? "◯" : ""));
+                tbody.append(tr);
+            });
+        }
+    }
+    function editResult(res) {
+        alert(res && res.ok ? "保存しました" : "失敗しました");
+    }
+    $("#searchBtn").on("click", function(){
+        IMART.call("jsspRpcListUsers", { q: $("#query").val() }, true);
+    });
+    $("#saveBtn").on("click", function(){
+        var p = {
+            userCd: $("#editUserCd").val(),
+            userName: $("#editUserName").val(),
+            emailAddress1: $("#editEmail").val(),
+            locale: "ja"
+        };
+        IMART.call("jsspRpcEditUser", p, true);
+    });
+    </script>
+</body>
+</html>

--- a/src/main/jssp/src/lo/contents/screen/account/user_maintenance.js
+++ b/src/main/jssp/src/lo/contents/screen/account/user_maintenance.js
@@ -1,0 +1,87 @@
+/**
+ * ユーザー一覧取得
+ * 入力: params = { q?, start?, count?, locale? }
+ * 返り: { ok, start, count, total, rows: [{userCd, displayName, deleted}] }
+ */
+function listUsers(params) {
+  var q      = (params && params.q)      || null;
+  var start  = Number((params && params.start) || 1);
+  var count  = Number((params && params.count) || 50);
+  var locale = (params && params.locale) || "ja";
+
+  var um   = new IMMUserManager();
+  var cond = new AppCmnSearchCondition();
+  var today = new Date();
+
+  if (q && q.trim() !== "") {
+    cond.addLikeWithIndex(1, "imm_user.user_cd", q.trim(), AppCmnSearchCondition.PARTIAL);
+  }
+
+  var resList = um.listUser(cond, today, locale, start, count, false);
+  var items   = (resList && resList.data) ? resList.data : [];
+
+  var resCnt  = um.countUser(cond, today, locale, false);
+  var total   = (resCnt && typeof resCnt.data === "number") ? resCnt.data : 0;
+
+  var rows = [];
+  for (var i = 0; i < items.length; i++) {
+    var n = items[i];
+    rows.push({
+      userCd: n.userCd,
+      displayName: n.displayName,
+      deleted: !!n.deleteFlag
+    });
+  }
+
+  return { ok: true, start: start, count: count, total: total, rows: rows };
+}
+
+/**
+ * ユーザー登録・更新
+ * 入力: params = { userCd, userName?, emailAddress1?, locale? }
+ * 返り: { ok, created, termChanges }
+ */
+function editUser(params) {
+  if (!params || !params.userCd) {
+    return { ok: false, error: "userCd is required." };
+  }
+  var userCd = params.userCd;
+  var userName = params.userName;
+  var email1   = params.emailAddress1;
+  var locale   = params.locale || "ja";
+
+  var um  = new IMMUserManager();
+  var app = new AppCommonManager();
+  var key = { userCd: userCd };
+  var today = new Date();
+
+  var got = um.getUser(key, today, locale, false);
+  var u   = got ? got.data : null;
+
+  var created = false;
+
+  if (!u) {
+    u = {
+      userCd: userCd,
+      termCd: null,
+      startDate: app.getSystemStartDate(),
+      endDate:   app.getSystemEndDate(),
+      deleteFlag: false,
+      locales: {}
+    };
+    created = true;
+  }
+
+  if (!u.locales) u.locales = {};
+  if (!u.locales[locale]) u.locales[locale] = {};
+  if (typeof userName === "string") u.locales[locale].userName = userName;
+  if (typeof email1   === "string") u.emailAddress1 = email1;
+
+  var upd = um.setUser(u);
+
+  return {
+    ok: true,
+    created: created,
+    termChanges: (upd && upd.data) ? upd.data : []
+  };
+}


### PR DESCRIPTION
## Summary
- add simple HTML sample for user maintenance
- implement listUsers and editUser SSJS handlers

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfc994a0f0832cbcfda852a04f9449