### PR TITLE
Fix script loading errors on user maintenance page

### DIFF
--- a/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
+++ b/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
@@ -2,15 +2,17 @@
     <html lang="ja">
     <meta charset="UTF-8">
     <title>ユーザーメンテナンスサンプル</title>
-    <link rel="stylesheet" type="text/css" href="lo_csjs/bootstrap.css">
-    <script type="text/javascript" src="lo_csjs/jquery-3.3.1.min.js"></script>
-    <script type="text/javascript" src="lo_csjs/bootstrap.min.js"></script>
+    <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">
+    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
+    <script src="https://unpkg.com/tabulator-tables@4.9.3/dist/js/tabulator.min.js"></script>
+    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
     <script type="text/javascript">
       window.IMART = window.IMART || {
         call: function(name, params, async) {
           console.warn('IMART.call stub invoked for', name, params);
         }
       };
+      var IMART = window.IMART;
     </script>
     <IMART type="jsspRpc" name="jsspRpcListUsers" page="lo/contents/screen/account/user_maintenance" callback="renderList"></IMART>
     <IMART type="jsspRpc" name="jsspRpcEditUser" page="lo/contents/screen/account/user_maintenance" callback="editResult"></IMART>


### PR DESCRIPTION
## Summary
- Load jQuery, Bootstrap, and Tabulator from public CDNs
- Define IMART stub to avoid runtime errors when backend APIs are absent

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68bfd6bdee7c832c9ee21a35396fd3ef