### PR TITLE
Remove jQuery3 scripts and harden IM UI messaging

### DIFF
--- a/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
+++ b/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
@@ -4,14 +4,6 @@
     <meta charset="UTF-8">
     <title>ユーザーメンテナンスサンプル</title>
     <link rel="stylesheet" href="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/css/bootstrap.min.css">
-    <script src="https://code.jquery.com/jquery-3.7.1.min.js"></script>
-    <script src="https://code.jquery.com/jquery-migrate-3.4.1.min.js"></script>
-    <script src="https://code.jquery.com/ui/1.13.2/jquery-ui.min.js"></script>
-
-    <script src="https://unpkg.com/tabulator-tables@4.9.3/dist/js/tabulator.min.js"></script>
-    <script src="https://cdn.jsdelivr.net/npm/bootstrap@4.6.2/dist/js/bootstrap.bundle.min.js"></script>
-<script type="text/javascript" src="lo_csjs/jquery.dataTables.min.js"></script>
-<script type="text/javascript" src="lo_csjs/lo_common.js"></script>
 </imart>
 <body id="body" class="container mt-3">
     <h1>ユーザーメンテナンスサンプル</h1>
@@ -47,7 +39,19 @@
         }
     }
     function editResult(res) {
-        alert(res && res.ok ? "保存しました" : "失敗しました");
+        var message = res && res.ok ? "保存しました" : "失敗しました";
+        var messageType = res && res.ok ? "message" : "warning";
+        if (message) {
+            try {
+                $("<div>" + message + "</div>").imuiMessageDialog({
+                    iconType: 'im-ui-icon-common-24-confirmation',
+                    title: (messageType === 'warning') ? '警告' : 'メッセージ',
+                    modal: true
+                });
+            } catch (e) {
+                alert(message);
+            }
+        }
     }
     $("#searchBtn").on("click", function(){
         var res = jsspRpcUserMaintenance.listUsers({ q: $("#query").val() });
@@ -63,6 +67,23 @@
         var res = jsspRpcUserMaintenance.editUser(p);
         editResult(res);
     });
+    </script>
+    <script>
+      (function($){
+        if ($.fn.imuiDropdown) {
+          $("#imui-nav-help-dropdown").imuiDropdown({ openOnMouseOver:false });
+        }
+      })(jQuery);
+
+      if ($.fn.imuiChangeFontSize) {
+        $('#imui-font-size-change').imuiChangeFontSize({
+          title: '文字サイズ',
+          isEnabledFontSizeChange: true,
+          isEnabledFontSizeChangePath: true
+        });
+      } else {
+        $('#imui-font-size-change').empty();
+      }
     </script>
 </body>
 </html>


### PR DESCRIPTION
## Summary
- strip jQuery 3.x and other extraneous libraries from user maintenance page
- replace success alert with IM UI message dialog and safe fallback
- guard optional IM UI plugins to prevent errors if absent

## Testing
- `npm test` *(fails: could not read package.json)*
- `mvn -q test` *(fails: missing POM)*

------
https://chatgpt.com/codex/tasks/task_e_68bfe5465870832ca57bbe5429dffbb9