### PR TITLE
Handle required dates in user maintenance sample

### DIFF
--- a/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
+++ b/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
@@ -22,6 +22,8 @@
         <input type="text" id="editUserCd" class="form-control mb-1" placeholder="userCd">
         <input type="text" id="editUserName" class="form-control mb-1" placeholder="userName">
         <input type="text" id="editEmail" class="form-control mb-1" placeholder="emailAddress1">
+        <input type="date" id="editStartDate" class="form-control mb-1" placeholder="startDate">
+        <input type="date" id="editEndDate" class="form-control mb-1" placeholder="endDate">
         <button id="saveBtn" class="btn btn-success">保存</button>
     </div>
     <script type="text/javascript">
@@ -62,6 +64,8 @@
             userCd: $("#editUserCd").val(),
             userName: $("#editUserName").val(),
             emailAddress1: $("#editEmail").val(),
+            startDate: $("#editStartDate").val(),
+            endDate: $("#editEndDate").val(),
             locale: "ja"
         };
         var res = jsspRpcUserMaintenance.editUser(p);

--- a/src/main/jssp/src/lo/contents/screen/account/user_maintenance.js
+++ b/src/main/jssp/src/lo/contents/screen/account/user_maintenance.js
@@ -48,6 +48,8 @@ function editUser(params) {
   var userCd = params.userCd;
   var userName = params.userName;
   var email1   = params.emailAddress1;
+  var startDate = params.startDate ? new Date(params.startDate) : null;
+  var endDate   = params.endDate ? new Date(params.endDate) : null;
   var locale   = params.locale || "ja";
 
   var um  = new IMMUserManager();
@@ -64,13 +66,19 @@ function editUser(params) {
     u = {
       userCd: userCd,
       termCd: null,
-      startDate: app.getSystemStartDate(),
-      endDate:   app.getSystemEndDate(),
+      startDate: startDate || app.getSystemStartDate(),
+      endDate:   endDate   || app.getSystemEndDate(),
       deleteFlag: false,
       locales: {}
     };
     created = true;
+  } else {
+    if (startDate) u.startDate = startDate;
+    if (endDate)   u.endDate   = endDate;
   }
+
+  if (!u.startDate) u.startDate = app.getSystemStartDate();
+  if (!u.endDate)   u.endDate   = app.getSystemEndDate();
 
   if (!u.locales) u.locales = {};
   if (!u.locales[locale]) u.locales[locale] = {};


### PR DESCRIPTION
## Summary
- capture start and end dates in user maintenance screen
- ensure server-side user update sets start/end dates when missing

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_68bfe9001930832c89afe204e675a54d