### PR TITLE
Handle required fields in user maintenance sample

### DIFF
--- a/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
+++ b/src/main/jssp/src/lo/contents/screen/account/user_maintenance.html
@@ -19,8 +19,18 @@
     </table>
     <h2 class="mt-4">編集</h2>
     <div class="mb-3">
-        <input type="text" id="editUserCd" class="form-control mb-1" placeholder="userCd">
-        <input type="text" id="editUserName" class="form-control mb-1" placeholder="userName">
+        <input type="text" id="editUserCd" class="form-control mb-1" placeholder="userCd" required>
+        <input type="text" id="editLocaleId" class="form-control mb-1" placeholder="localeId" required>
+        <input type="text" id="editTermCd" class="form-control mb-1" placeholder="termCd" required>
+        <input type="date" id="editStartDate" class="form-control mb-1" placeholder="startDate" required>
+        <input type="date" id="editEndDate" class="form-control mb-1" placeholder="endDate" required>
+        <input type="text" id="editUserName" class="form-control mb-1" placeholder="userName" required>
+        <input type="text" id="editDeleteFlag" class="form-control mb-1" placeholder="deleteFlag" required>
+        <input type="number" id="editSortKey" class="form-control mb-1" placeholder="sortKey" required>
+        <input type="text" id="editCreateUserCd" class="form-control mb-1" placeholder="createUserCd" required>
+        <input type="datetime-local" id="editCreateDate" class="form-control mb-1" placeholder="createDate" required>
+        <input type="text" id="editRecordUserCd" class="form-control mb-1" placeholder="recordUserCd" required>
+        <input type="datetime-local" id="editRecordDate" class="form-control mb-1" placeholder="recordDate" required>
         <input type="text" id="editEmail" class="form-control mb-1" placeholder="emailAddress1">
         <button id="saveBtn" class="btn btn-success">保存</button>
     </div>
@@ -58,11 +68,21 @@
         renderList(res);
     });
     $("#saveBtn").on("click", function(){
+        var deleteFlagStr = $("#editDeleteFlag").val();
         var p = {
             userCd: $("#editUserCd").val(),
+            locale: $("#editLocaleId").val(),
+            termCd: $("#editTermCd").val(),
+            startDate: $("#editStartDate").val(),
+            endDate: $("#editEndDate").val(),
             userName: $("#editUserName").val(),
-            emailAddress1: $("#editEmail").val(),
-            locale: "ja"
+            deleteFlag: deleteFlagStr === "1" || deleteFlagStr === "true",
+            sortKey: Number($("#editSortKey").val()),
+            createUserCd: $("#editCreateUserCd").val(),
+            createDate: $("#editCreateDate").val(),
+            recordUserCd: $("#editRecordUserCd").val(),
+            recordDate: $("#editRecordDate").val(),
+            emailAddress1: $("#editEmail").val()
         };
         var res = jsspRpcUserMaintenance.editUser(p);
         editResult(res);

--- a/src/main/jssp/src/lo/contents/screen/account/user_maintenance.js
+++ b/src/main/jssp/src/lo/contents/screen/account/user_maintenance.js
@@ -38,17 +38,31 @@ function listUsers(params) {
 
 /**
  * ユーザー登録・更新
- * 入力: params = { userCd, userName?, emailAddress1?, locale? }
+ * 入力: params = { userCd, locale, termCd, startDate, endDate, userName,
+ *                  deleteFlag, sortKey, createUserCd, createDate,
+ *                  recordUserCd, recordDate, emailAddress1? }
  * 返り: { ok, created, termChanges }
  */
 function editUser(params) {
-  if (!params || !params.userCd) {
-    return { ok: false, error: "userCd is required." };
+  if (!params || !params.userCd || !params.locale || !params.termCd ||
+      !params.startDate || !params.endDate || !params.userName ||
+      typeof params.deleteFlag === "undefined" || typeof params.sortKey === "undefined" ||
+      !params.createUserCd || !params.createDate || !params.recordUserCd || !params.recordDate) {
+    return { ok: false, error: "required field missing." };
   }
   var userCd = params.userCd;
   var userName = params.userName;
   var email1   = params.emailAddress1;
-  var locale   = params.locale || "ja";
+  var startDate = new Date(params.startDate);
+  var endDate   = new Date(params.endDate);
+  var locale   = params.locale;
+  var termCd = params.termCd;
+  var deleteFlag = !!params.deleteFlag;
+  var sortKey = Number(params.sortKey);
+  var createUserCd = params.createUserCd;
+  var createDate = new Date(params.createDate);
+  var recordUserCd = params.recordUserCd;
+  var recordDate = new Date(params.recordDate);
 
   var um  = new IMMUserManager();
   var app = new AppCommonManager();
@@ -63,14 +77,32 @@ function editUser(params) {
   if (!u) {
     u = {
       userCd: userCd,
-      termCd: null,
-      startDate: app.getSystemStartDate(),
-      endDate:   app.getSystemEndDate(),
-      deleteFlag: false,
+      termCd: termCd,
+      startDate: startDate || app.getSystemStartDate(),
+      endDate:   endDate   || app.getSystemEndDate(),
+      deleteFlag: deleteFlag,
+      sortKey: sortKey,
+      createUserCd: createUserCd,
+      createDate: createDate,
+      recordUserCd: recordUserCd,
+      recordDate: recordDate,
       locales: {}
     };
     created = true;
+  } else {
+    u.termCd = termCd;
+    u.startDate = startDate;
+    u.endDate   = endDate;
+    u.deleteFlag = deleteFlag;
+    u.sortKey = sortKey;
+    u.createUserCd = createUserCd;
+    u.createDate = createDate;
+    u.recordUserCd = recordUserCd;
+    u.recordDate = recordDate;
   }
+
+  if (!u.startDate) u.startDate = app.getSystemStartDate();
+  if (!u.endDate)   u.endDate   = app.getSystemEndDate();
 
   if (!u.locales) u.locales = {};
   if (!u.locales[locale]) u.locales[locale] = {};


### PR DESCRIPTION
## Summary
- collect locale, term, date range, deletion flag, sort key and audit fields in user maintenance UI
- validate and persist new required fields when saving users

## Testing
- `npm test` (fails: ENOENT: no such file or directory, open 'package.json')

------
https://chatgpt.com/codex/tasks/task_e_68bfe9001930832c89afe204e675a54d